### PR TITLE
Add try catch for large data

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipelinedb/stride",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Stride.io JavaScript API client",
   "main": "index.js",
   "scripts": {

--- a/src/stride.js
+++ b/src/stride.js
@@ -115,7 +115,11 @@ function SubscribeObjectTransform() {
     let objects = chunk.toString('utf8').trim().split('\r\n')
     for (let obj of objects) {
       if (obj = obj.trim()) {
-        obj = JSON.parse(obj)
+        try {
+          obj = JSON.parse(obj)
+        } catch(e) {
+          return
+        }
         if (obj && typeof obj === 'object') this.push(obj)
       }
     }

--- a/src/stride.js
+++ b/src/stride.js
@@ -118,7 +118,7 @@ function SubscribeObjectTransform() {
         try {
           obj = JSON.parse(obj)
         } catch(e) {
-          return
+          return console.error(e)
         }
         if (obj && typeof obj === 'object') this.push(obj)
       }


### PR DESCRIPTION
When receiving larger JSON strings, web sockets sends the data in chunks. This was causing the server to crash when trying the parse the chunked data.